### PR TITLE
RTC-12600 Suppress close event on browser reload

### DIFF
--- a/spec/netHandler.spec.ts
+++ b/spec/netHandler.spec.ts
@@ -32,7 +32,7 @@ describe('net handler', () => {
     it('success', () => {
       const connection = netHandler.connect(
         webContentsMocked as any,
-        '\\\\?\\pipe\\c9Controller',
+        '\\\\?\\pipe\\symphony-1-1',
       );
       expect(connection).toBeTruthy();
       expect(webContentsMocked.send).toHaveBeenCalledWith(
@@ -44,7 +44,7 @@ describe('net handler', () => {
     it('data', () => {
       const connection = netHandler.connect(
         webContentsMocked as any,
-        '\\\\?\\pipe\\c9Controller',
+        '\\\\?\\pipe\\symphony-1-1',
       );
       expect(connection).toBeTruthy();
       mockConnectionEvents.get('data')('the data');


### PR DESCRIPTION
When the browser is reloaded, all open pipe connections are explicitly
closed. This triggers a 'close' event that is sent to the Cloud9
extension, which goes into a reconnect loop. Now, the extension manages
to reconnect before it is unloaded, which hogs the pipe connetion so
that the spawned extension instance cannot connect.

This commit fixes this problem by suppressing the close event when a
connection is explicitly closed. The reconnect loop will still work fine
when the connection is lost due to an error, or the server side closes
it.